### PR TITLE
Made tiny change on include section to adapt compile on OSX

### DIFF
--- a/coroutine.c
+++ b/coroutine.c
@@ -1,11 +1,16 @@
 #include "coroutine.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <ucontext.h>
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
 #include <stdint.h>
+
+#if __APPLE__ && __MACH__
+	#include <sys/ucontext.h>
+#else 
+	#include <ucontext.h>
+#endif 
 
 #define STACK_SIZE (1024*1024)
 #define DEFAULT_COROUTINE 16


### PR DESCRIPTION
Hi, Cloud, 
      
      I am study coroutine, and found this project on your repository. I tried to compile and received the compile error as following, 

>/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/ucontext.h:43:2: error: The
>       deprecated ucontext routines require _XOPEN_SOURCE to be defined
> #error The deprecated ucontext routines require _XOPEN_SOURCE to be defined   
 
This issue is reported as in article, 
> http://duriansoftware.com/joe/PSA:-avoiding-the-%22ucontext-routines-are-deprecated%22-error-on-Mac-OS-X-Snow-Leopard.html

compiler macro refer to 
> https://sourceforge.net/p/predef/wiki/OperatingSystems/

Thank you your implementation of coroutine. 


